### PR TITLE
Add unit tests for store credentials

### DIFF
--- a/identity/store_test.go
+++ b/identity/store_test.go
@@ -1,0 +1,71 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * This file is part of the IoT Agent
+ * Copyright 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+ * SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package identity
+
+import (
+	"github.com/CanonicalLtd/iot-agent/config"
+	"github.com/CanonicalLtd/iot-agent/snapdapi"
+	"github.com/CanonicalLtd/iot-identity/domain"
+	. "gopkg.in/check.v1"
+	"os"
+	"testing"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type StoreTestSuite struct {
+	credentialsPath string
+	identityURL     string
+	snapdMockClient *snapdapi.MockClient
+}
+
+var _ = Suite(&StoreTestSuite{})
+
+func (s *StoreTestSuite) SetUpTest(c *C) {
+	s.credentialsPath = ".test"
+	s.identityURL = ""
+	os.Remove(s.credentialsPath)
+
+	s.snapdMockClient = &snapdapi.MockClient{WithError: false}
+}
+
+func (s *StoreTestSuite) TearDownSuite(c *C) {
+	os.Remove(s.credentialsPath)
+}
+
+func (s *StoreTestSuite) TestStoreCredentialsValid(c *C) {
+	settings := &config.Settings{
+		IdentityURL:     s.identityURL,
+		CredentialsPath: s.credentialsPath,
+	}
+
+	srv := &Service{
+		Settings: settings,
+		Snapd:    s.snapdMockClient,
+	}
+	enroll := domain.Enrollment{}
+	err := srv.storeCredentials(enroll)
+
+	c.Assert(err, IsNil)
+
+	_, err = os.Stat(settings.CredentialsPath)
+	c.Assert(err, IsNil)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -261,6 +261,12 @@
 			"revisionTime": "2019-04-01T07:06:21Z"
 		},
 		{
+			"checksumSHA1": "9gypWnVZJEaH3jMK9KqOp4xgQD4=",
+			"path": "gopkg.in/check.v1",
+			"revision": "788fd78401277ebd861206a03c884797c6ec5541",
+			"revisionTime": "2018-06-28T17:31:08Z"
+		},
+		{
 			"checksumSHA1": "t95/FNK2nGCx3e6IARbO7OrcCuY=",
 			"path": "gopkg.in/tomb.v2",
 			"revision": "d5d1b5820637886def9eef33e03a27a9f166942c",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -63,6 +63,18 @@
 			"revisionTime": "2019-03-16T13:32:43Z"
 		},
 		{
+			"checksumSHA1": "3ohk4dFYrERZ6WTdKkIwnTA0HSI=",
+			"path": "github.com/kr/pretty",
+			"revision": "73f6ac0b30a98e433b289500d779f50c1a6f0712",
+			"revisionTime": "2018-05-06T08:33:45Z"
+		},
+		{
+			"checksumSHA1": "SbguDK5lY8uhaHNrmJmNbiWIGM0=",
+			"path": "github.com/kr/text",
+			"revision": "e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f",
+			"revisionTime": "2018-05-06T08:24:08Z"
+		},
+		{
 			"checksumSHA1": "nV76VgoCpwa+JjK/tSyu5jCj8HQ=",
 			"path": "github.com/ojii/gettext.go",
 			"revision": "b6dae1d7af8a8441285e42661565760b530a8a57",


### PR DESCRIPTION
I imported Go Check package(gopkg.in/check.v1) which makes unit tests are manageable aside from the storeCredentials method's unit test. If it is ok, I can convert other unit tests working using this package.